### PR TITLE
Working expectation point on container opening brace

### DIFF
--- a/src/liberty_grammar.hpp
+++ b/src/liberty_grammar.hpp
@@ -22,7 +22,7 @@ struct liberty_grammar : qi::grammar<iterator, std::vector<ast::container_t>(),
     libs = +container > qi::eoi;
 
     element = container | list | pair;
-    container = name >> '(' >> -(arg % ',') >> ')' >> '{' >> +element > '}';
+    container = name >> '(' >> -(arg % ',') >> ')' >> ('{' > +element > '}');
     list = name >> '(' > (value % ',') > ')' > ';';
     pair = name >> ':' > value > ';';
 


### PR DESCRIPTION
Proof Of Fix for the problem expositioned in https://stackoverflow.com/questions/49262688/spirit-qi-error-when-replacing-sequence-with-expectation-operator/49267436#49267436

> Because the precedences of `operator>>` and `operator>` aren't equal, the resulting "synthesized attribute type is different.

> In fact, it is no longer automatically compatible with the intended exposed attribute type.

> In this case the problem can be quickly neutralized with some disambiguating parentheses around the sub-expression:

>     container = name >> '(' >> -(arg % ',') >> ')' >> ('{' > +element > '}');